### PR TITLE
Switch to using blockchair ethereum API

### DIFF
--- a/check_ethereum_blockchain
+++ b/check_ethereum_blockchain
@@ -71,7 +71,7 @@ local_blockchain10=$(($local_blockchain16))
 #
 # Get Remote Data
 #
-remote_count=$(curl https://www.etherchain.org/api/blocks/count -sSf | jq -r ".count" )
+remote_count=$(curl https://api.blockchair.com/ethereum -sSf | jq -r ".[0].mempool_best_block")
 if [ $? -ne "0" ]; then
 	echo "UNKNOWN- Could not fetch remote information"
 	exit 3

--- a/check_ethereum_blockchain
+++ b/check_ethereum_blockchain
@@ -71,7 +71,7 @@ local_blockchain10=$(($local_blockchain16))
 #
 # Get Remote Data
 #
-remote_count=$(curl https://api.blockchair.com/ethereum -sSf | jq -r ".[0].mempool_best_block")
+remote_count=$(curl https://api.blockchair.com/ethereum/stats -sSf | jq -r ".data.blocks")
 if [ $? -ne "0" ]; then
 	echo "UNKNOWN- Could not fetch remote information"
 	exit 3


### PR DESCRIPTION
Previous external API provider etherchain seems to be blocking anonymous API requests through use of Cloudflare as of 21/08/18, so move to a new provider for remote data